### PR TITLE
Adding has_edits Flag to YRoomMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased - 11.9.2023
+
+### Added
+
+- `YRoomMessage.has_edits: bool` flag indicating data changes have occurred.
+
+## v0.0.8

--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ pip install yroom
 ## API
 
 See `yroom.pyi`.
+
+## Development
+
+[Maturin](https://www.maturin.rs) can be used to build `Yroom` inside a virtual environment.
+
+```
+maturin develop
+```

--- a/src/roomsync.rs
+++ b/src/roomsync.rs
@@ -592,7 +592,6 @@ impl YRoom {
                     }
                 }
                 Message::Sync(SyncMessage::SyncStep2(data)) => {
-                    has_edits = true;
                     let update = match self.settings.protocol_version {
                         ProtocolVersion::V1 => Update::decode_v1(&data),
                         ProtocolVersion::V2 => Update::decode_v2(&data),
@@ -604,9 +603,9 @@ impl YRoom {
                         }
                         Err(e) => log::error!("Error decoding sync step 2: {}", e),
                     }
+                    has_edits = true;
                 }
                 Message::Sync(SyncMessage::Update(data)) => {
-                    has_edits = true;
                     let update = Update::decode_v1(&data);
                     match update {
                         Ok(update) => {
@@ -617,6 +616,7 @@ impl YRoom {
                         }
                         Err(e) => log::error!("Error decoding update: {}", e),
                     }
+                    has_edits = true;
                 }
                 Message::Auth(_) => {
                     // TODO: check this. Always reply with permission granted

--- a/src/roomsync.rs
+++ b/src/roomsync.rs
@@ -5,7 +5,7 @@ use std::{
 
 use pyo3::{
     prelude::*,
-    types::{PyBytes, PyDict, PyList, PyBool},
+    types::{PyBytes, PyDict, PyList},
 };
 
 use lib0::{
@@ -248,7 +248,7 @@ impl YRoomMessage {
         Python::with_gil(|py| YRoomMessage {
             payloads: make_payloads(py, payloads),
             broadcast_payloads: make_payloads(py, broadcast_payloads),
-            has_edits: PyBool::new(py, has_edits).into(),
+            has_edits: has_edits.into_py(py),
         })
     }
 }
@@ -263,7 +263,7 @@ impl Default for YRoomMessage {
 impl YRoomMessage {
     pub fn __str__(&self) -> String {
         format!(
-            "YRoomMessage(payloads: {}, broadcast_payloads: {}, has_edits{})",
+            "YRoomMessage(payloads: {}, broadcast_payloads: {}, has_edits: {})",
             self.payloads, self.broadcast_payloads, self.has_edits
         )
     }
@@ -537,7 +537,7 @@ impl YRoom {
         Python::with_gil(|py| YRoomMessage {
             payloads: make_payloads(py, &payloads),
             broadcast_payloads: make_payloads(py, &[]),
-            has_edits: PyBool::new(py, false).into(),
+            has_edits: false.into_py(py),
         })
     }
 
@@ -592,6 +592,7 @@ impl YRoom {
                     }
                 }
                 Message::Sync(SyncMessage::SyncStep2(data)) => {
+                    has_edits = true;
                     let update = match self.settings.protocol_version {
                         ProtocolVersion::V1 => Update::decode_v1(&data),
                         ProtocolVersion::V2 => Update::decode_v2(&data),

--- a/src/roomsync.rs
+++ b/src/roomsync.rs
@@ -263,8 +263,8 @@ impl Default for YRoomMessage {
 impl YRoomMessage {
     pub fn __str__(&self) -> String {
         format!(
-            "YRoomMessage(payloads: {}, broadcast_payloads: {})",
-            self.payloads, self.broadcast_payloads
+            "YRoomMessage(payloads: {}, broadcast_payloads: {}, has_edits{})",
+            self.payloads, self.broadcast_payloads, self.has_edits
         )
     }
 

--- a/yroom.pyi
+++ b/yroom.pyi
@@ -6,10 +6,12 @@ class YRoomMessage:
     `payload` is a message that should be sent to the connection that sent the message.
     `broadcast_payload` is a message that should be sent to all connections in the room.
     Either or both of the members can be of zero length and then must not be sent.
+    `has_edits` flag indicates if data changes occurred. Does not include awareness updates.
     """
 
     payloads: List[bytes]
     broadcast_payloads: List[bytes]
+    has_edits: bool
 
 class YRoomSettings(TypedDict):
     wire_version: int  # The Yjs encoding/decoding version to use (1 or 2, default: 1)


### PR DESCRIPTION
# Motivation

Relaying if the room data *changed* from `YRoomManager` to the outside. Used for improved implementation of [Autosave Feature in channels_yroom](https://github.com/stefanw/channels-yroom/pull/14).

# Testing

Changes did not break current test suite.

# Open Questions

- Should [YRoomMessage.has_edits](https://github.com/atheler/yroom/blob/ded2772c88f2546e64ffe97bf166312adcf85e03/src/roomsync.rs#L239) be optional attribute `has_edits: bool = False`?
- When connecting to a room is [`has_room = false`](https://github.com/atheler/yroom/blob/ded2772c88f2546e64ffe97bf166312adcf85e03/src/roomsync.rs#L540C5-L540C5)?


Let me know what you think!
